### PR TITLE
fix spelling error for PRODUCTION_PASSWORD to get heroku up

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -17,6 +17,6 @@ test:
   secret_key_base: d15daff660c7c1ac8e55708aaa899bcae839c6afc7d81ddb6e6c1215b9c7bbabd340ea2262c6156ba08d183ba779686e0ad85e5915fea8e4e73f41b7af841ef2
 
 production:
-  secret_key_base: <%=ENV['PRODUCITON_PASSWORD']%>
+  secret_key_base: <%=ENV['PRODUCTION_PASSWORD']%>
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
What does this PR do?
fixes a spelling error, in the process of pushing our secret key up to heroku. gave us some problems

Where should the reviewer start?
the only file changed

How should this be manually tested?
heroku should work

Any background context you want to provide?
no

What are the relevant tickets?
none

Screenshots (if appropriate)
not appropriate

Questions:


- Do Migrations Need to be ran?
NO
- Do Environment Variables need to be set?
DONE
- Any other deploy steps?
NO
